### PR TITLE
Enable Javascript Behat tests in CircleCI

### DIFF
--- a/generators/app/templates/_behat.yml
+++ b/generators/app/templates/_behat.yml
@@ -52,7 +52,9 @@ circle:
   extensions:
     Behat\MinkExtension:
       base_url: http://<%= dashedAppName %>.dev
-      selenium2: ~
+      selenium2:
+        wd_host: 'http://127.0.0.1:4444/wd/hub'
+        browser: 'chrome'
       browser_name: chrome
     Drupal\DrupalExtension:
       drupal:

--- a/generators/app/templates/circleci/config.yml
+++ b/generators/app/templates/circleci/config.yml
@@ -3,6 +3,7 @@ jobs:
   build:
     docker:
       - image: tbfisher/drupal-nginx:php-7.1.x
+      - image: selenium/standalone-chrome-debug:3.6.0
       - image: mariadb:5.5
         environment:
           MYSQL_DATABASE: drupal
@@ -39,13 +40,6 @@ jobs:
             php -r "unlink('composer-setup.php');"
             mv composer.phar /usr/bin/composer
       - run:
-          name: Install and configure drush
-          command: |
-            composer global require drush/drush:8.* --no-interaction
-            mkdir -p ~/.drush
-            cp ./.circleci/<%= appName %>.aliases.drushrc.php ~/.drush
-            drush cc drush
-      - run:
           name: Configure Nginx
           command: |
             cp ./.circleci/<%= appName %> /etc/nginx/sites-available/default
@@ -55,8 +49,9 @@ jobs:
             cp ./.circleci/settings.secret.php ./settings/
             composer install
             chmod 777 -R ./web/sites/default/files
-            drush site-set @<%= appName %>.<%= dashedAppName %>.dev
-            if [ -f /var/www/<%= appName %>/config/sync/core.extension.yml ] ; then echo 'Install with config' ; /usr/bin/env PHP_OPTIONS="-d sendmail_path=`which true`" drush si <%= appName %> -y ; drush config-set "system.site" uuid $SITE_UUID -y ; drush cim -y ; else echo 'Install without config' ; /usr/bin/env PHP_OPTIONS="-d sendmail_path=`which true`" drush si <%= appName %> -y ; fi
+            cd web
+            if [ -f /var/www/<%= appName %>/config/sync/core.extension.yml ] ; then echo 'Install with config' ; /usr/bin/env PHP_OPTIONS="-d sendmail_path=`which true`" ../vendor/bin/drush si <%= appName %> -y ; ../vendor/bin/drush config-set "system.site" uuid $SITE_UUID -y ; ../vendor/bin/drush cim -y ; else echo 'Install without config' ; /usr/bin/env PHP_OPTIONS="-d sendmail_path=`which true`" ../vendor/bin/drush si <%= appName %> -y ; fi
+            cd /var/www/<%= appName %>
       - run:
           name: Coding Standards Linters
           command: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-humpback",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Generate a Drupal project using humpback",
   "homepage": "https://humpbackdev.com",
   "author": {


### PR DESCRIPTION
This PR:
- Fixes installation when drupal > 8.4.0 (uses drush 9)
- Add selenium image to run behat tests with javascript
- Increase version number