### PR TITLE
Prevent issues with pantheon and git submodules during deploy for themes.

### DIFF
--- a/generators/app/templates/_site.ahoy.yml
+++ b/generators/app/templates/_site.ahoy.yml
@@ -18,6 +18,7 @@ commands:
       cd ../
       composer install --no-dev --ignore-platform-reqs
       find ./web/modules/contrib/ -name ".git" -exec rm -rf {} \;
+      find ./web/themes/contrib/ -name ".git" -exec rm -rf {} \;
       find ./web/sites/all/assets/vendor/ -name ".git" -exec rm -rf {} \;
       find ./web/libraries/ -name ".git" -exec rm -rf {} \;
       find ./web/sites/all/libraries/ -name ".git" -exec rm -rf {} \;


### PR DESCRIPTION

- Add a command to delete all the .git folders inside `themes/contrib` during deploy.