### PR TITLE
Update traefik configuration so that you can have several humpback instances running and proxy still works.

### DIFF
--- a/generators/app/templates/_docker-compose.yml
+++ b/generators/app/templates/_docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - VIRTUAL_HOST=${VIRTUAL_HOST-localhost}
     labels:
       - 'traefik.enable=true'
-      - 'traefik.backend=nginx'
+      - 'traefik.backend=${VIRTUAL_HOST}-nginx'
       - 'traefik.frontend.rule=Host:${VIRTUAL_HOST-localhost}'
       - 'traefik.docker.network=humpback_proxy'
       - 'traefik.port=80'
@@ -131,7 +131,7 @@ services:
       - humpback_proxy
     labels:
       - 'traefik.enable=true'
-      - 'traefik.backend=varnish'
+      - 'traefik.backend=${VIRTUAL_HOST}-varnish'
       - 'traefik.frontend.rule=Host:varnish.${VIRTUAL_HOST-localhost}'
       - 'traefik.docker.network=humpback_proxy'
       - 'traefik.port=80'
@@ -148,7 +148,7 @@ services:
       - humpback_proxy
     labels:
       - 'traefik.enable=true'
-      - 'traefik.backend=mailhog'
+      - 'traefik.backend=${VIRTUAL_HOST}-mailhog'
       - 'traefik.frontend.rule=Host:mailhog.${VIRTUAL_HOST-localhost}'
       - 'traefik.docker.network=humpback_proxy'
       - 'traefik.port=8025'


### PR DESCRIPTION
How to test:
- Generate TWO different projects (with different names)
- Install sites
- Navigate to both of them using proxy urls (<name>.docker)
- Ensure proxy never send the requests to the wrong backend