### PR TITLE
Remove extra comma from composer.json on pantheon projects.

### DIFF
--- a/generators/app/templates/deploy-environment/Pantheon/composer.json
+++ b/generators/app/templates/deploy-environment/Pantheon/composer.json
@@ -21,7 +21,7 @@
     "drupal/core-recommended": "<%= coreVersion %>",
     "cweagans/composer-patches": "^1.6.5",
     "pantheon-systems/drupal-integrations": "^8.0",
-    "drush/drush": "^9.7.1 | ^10.0.0",
+    "drush/drush": "^9.7.1 | ^10.0.0"
   },
   "require-dev": {
     "testdrupal/behatextension": "dev-update",


### PR DESCRIPTION
## Description
When generating a new project for pantheon, if you run `ahoy composer install` the following error appears:

```
[Seld\JsonLint\ParsingException]
  "./composer.json" does not contain valid JSON
  Parse error on line 24:
  ...9.7.1 | ^10.0.0",  },  "require-dev":
  ---------------------^
  Expected: 'STRING' - It appears you have an extra trailing comma
```

Here I'm removing that extra comma.

## Steps to test
- [ ] Generate a new project using this branch
- [ ] Run `ahoy site local-settings`
- [ ] Run `ahoy composer install`, it shouldn't shown the error stated previously, the command should finish correctly.